### PR TITLE
Fix hyperpixel `dtparam` for inverted touchscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ $ sudo nano /boot/config.txt
 Add the following lines to the very end of the file:
 ```
 dtoverlay=vc4-kms-dpi-hyperpixel4
-dtparam=rotate=90,touchscreen-swapped-x-y,touchscreen-inverted-x
+dtparam=rotate=90,touchscreen-swapped-x-y,touchscreen-inverted-y
 ```
 See the following [issue](https://github.com/pimoroni/hyperpixel4/issues/177) for more information on configuring the Hyperpixel screen. 
 


### PR DESCRIPTION
The [linked](https://github.com/pimoroni/hyperpixel4/issues/177) issue mentions to use `touchscreen-inverted-y` for the case where the header is on the "bottom" of the screen in portrait mode. Using `touchscreen-inverted-x` flipped the wrong direction.

From the issue:

Finally use one of the following `dtparam` lines immediately underneath to set the parameters:

- ...
- `dtparam=rotate=90,touchscreen-swapped-x-y,touchscreen-inverted-y` - Landscape with header on the bottom
- ...