### PR TITLE
DAW Version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,18 @@ Replace `10.0.0.146` with whatever the IP was for your device. Now you should be
 ### Downloading the LMN-3 DAW
 ```
 $ cd ~
-$ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.0/LMN-3-aarch64-linux-gnu.zip
+$ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/<desired-version>/LMN-3-aarch64-linux-gnu.zip
 ```
-The URL used above is for the aarch64 application. If you are using a different architecture you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases/tag/v0.1.0).
+The URL used above is for the aarch64 application. If you are using a different architecture you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
+
+Please replace <desired-version> in the URL above with whatever version you want. 
+
+For example:  
+```
+https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.1/LMN-3-aarch64-linux-gnu.zip
+```
+
+The URL used above is for the aarch64 application. If you are using a different architecture you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
 
 After downloading, unzip the archive.
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Replace `10.0.0.146` with whatever the IP was for your device. Now you should be
 $ cd ~
 $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/<desired-version>/LMN-3-aarch64-linux-gnu.zip
 ```
-The URL used above is for the aarch64 application. If you are using a different architecture you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
+The URL used above is for the aarch64 application. If you are using a different version you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
 
 Please replace <desired-version> in the URL above with whatever version you want. 
 
@@ -218,8 +218,6 @@ For example:
 ```
 https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.1/LMN-3-aarch64-linux-gnu.zip
 ```
-
-The URL used above is for the aarch64 application. If you are using a different architecture you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
 
 After downloading, unzip the archive.
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ Replace `10.0.0.146` with whatever the IP was for your device. Now you should be
 $ cd ~
 $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/<desired-version>/LMN-3-aarch64-linux-gnu.zip
 ```
-The URL used above is for the aarch64 application. If you are using a different version you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
 
 Please replace <desired-version> in the URL above with whatever version you want. 
 
@@ -218,6 +217,7 @@ For example:
 ```
 $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.1/LMN-3-aarch64-linux-gnu.zip
 ```
+The URL used above is version 0.1.1 for the aarch64 application. If you are using a different version you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
 
 After downloading, unzip the archive.
 

--- a/README.md
+++ b/README.md
@@ -206,19 +206,22 @@ $ ssh pi@10.0.0.146
 Replace `10.0.0.146` with whatever the IP was for your device. Now you should be remotely connected to the Pi, and can execute commands inside on it in your terminal session.
 
 ### Downloading the LMN-3 DAW
+## 1
 ```
 $ cd ~
 $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/<desired-version>/LMN-3-aarch64-linux-gnu.zip
 ```
 The URL used above is for the aarch64 application. If you are using a different version you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
 
-##Please replace <desired-version> in the URL above with whatever version you want. 
+# Note
+Please replace <desired-version> in the URL above with whatever version you want. 
 
 For example:  
 ```
 $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.1/LMN-3-aarch64-linux-gnu.zip
 ```
 
+## 2 
 After downloading, unzip the archive.
 
 ```

--- a/README.md
+++ b/README.md
@@ -205,15 +205,13 @@ $ ssh pi@10.0.0.146
 
 Replace `10.0.0.146` with whatever the IP was for your device. Now you should be remotely connected to the Pi, and can execute commands inside on it in your terminal session.
 
-### Downloading the LMN-3 DAW
-## 1
+### Downloading the LMN-3 DAW 
 ```
 $ cd ~
 $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/<desired-version>/LMN-3-aarch64-linux-gnu.zip
 ```
 The URL used above is for the aarch64 application. If you are using a different version you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
 
-# Note
 Please replace <desired-version> in the URL above with whatever version you want. 
 
 For example:  
@@ -221,7 +219,6 @@ For example:
 $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.1/LMN-3-aarch64-linux-gnu.zip
 ```
 
-## 2 
 After downloading, unzip the archive.
 
 ```

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/<desi
 ```
 The URL used above is for the aarch64 application. If you are using a different version you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
 
-Please replace <desired-version> in the URL above with whatever version you want. 
+##Please replace <desired-version> in the URL above with whatever version you want. 
 
 For example:  
 ```
-https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.1/LMN-3-aarch64-linux-gnu.zip
+$ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.1/LMN-3-aarch64-linux-gnu.zip
 ```
 
 After downloading, unzip the archive.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ For example:
 ```
 $ wget https://github.com/FundamentalFrequency/LMN-3-DAW/releases/download/v0.1.1/LMN-3-aarch64-linux-gnu.zip
 ```
-The URL used above is version 0.1.1 for the aarch64 application. If you are using a different version you can find it [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases).
+The URL used above is version 0.1.1 for the aarch64 application. You can find releases for all available versions [here](https://github.com/FundamentalFrequency/LMN-3-DAW/releases). Each release contains a zip file for multiple architectures, so please make sure you download the zip file for the architecture you require. 
 
 After downloading, unzip the archive.
 


### PR DESCRIPTION
Changed part of the build guide to reflect new releases, and where to find future version releases. 

Old link was to release v0.1.0. 